### PR TITLE
fix: remove `luajit` from default feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,6 @@ luajit = ["mlua/luajit"]
 crate-type = ["cdylib"]
 
 [dependencies]
-mlua = { version = "0.9.9", features = ["luajit", "module"] }
+mlua = { version = "0.9.9", features = ["module"] }
 reqwest = { version = "=0.12.7", features = ["blocking", "native-tls-alpn"] }
 bstr = "1.10.0"


### PR DESCRIPTION
this blocks `lua-reqwest` from being installed with `luarocks make`

`luarocks-build-rust-mlua` adds detected lua version when running `cargo build` so we don't need to put default lua version.

actually the `mlua-sys` dependency build will break when the environment's lua version doesn't match with `luajit`