### PR TITLE
fix(lib.rs): remove debug print statement for connect_timeout

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,6 @@ fn request<'lua>(
         if opts.contains_key("connect_timeout").is_ok() {
             let value = opts.get::<_, LuaValue>("connect_timeout")?;
             if !value.is_nil() {
-                println!("connect_timeout");
                 let timeout = opts.get::<_, u64>("connect_timeout")?;
                 builder = builder.connect_timeout(std::time::Duration::from_secs(timeout));
             }


### PR DESCRIPTION
Removes a `println!` statement that was used for debugging the `connect_timeout` option. This statement is no longer necessary and was producing unwanted output during runtime.