### PR TITLE
feat: add luarocks publish workflow and 0.1.5 rockspec

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,10 @@ name: Publish to LuaRocks
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g. 0.1.5)'
+        required: true
   push:
     tags:
       - "*"
@@ -23,7 +27,7 @@ jobs:
         env:
           LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
         run: |
-          TAG="${GITHUB_REF#refs/tags/}"
+          TAG="${{ github.event.inputs.version || github.ref_name }}"
           ROCKSPEC="lua-reqwest-${TAG}-1.rockspec"
           if [ ! -f "$ROCKSPEC" ]; then
             echo "Error: $ROCKSPEC not found"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,4 +23,10 @@ jobs:
         env:
           LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
         run: |
-          luarocks upload lua-reqwest-0.1.5-1.rockspec --api-key="$LUAROCKS_API_KEY"
+          TAG="${GITHUB_REF#refs/tags/}"
+          ROCKSPEC="lua-reqwest-${TAG}-1.rockspec"
+          if [ ! -f "$ROCKSPEC" ]; then
+            echo "Error: $ROCKSPEC not found"
+            exit 1
+          fi
+          luarocks upload "$ROCKSPEC" --api-key="$LUAROCKS_API_KEY"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install LuaRocks
         uses: hishamhm/gh-actions-lua@master
         with:
-          luaVersion: "5.4"
+          luaVersion: "5.1"
 
       - uses: hishamhm/gh-actions-luarocks@master
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: Publish to LuaRocks
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install LuaRocks
+        uses: hishamhm/gh-actions-lua@master
+        with:
+          luaVersion: "5.4"
+
+      - uses: hishamhm/gh-actions-luarocks@master
+
+      - name: Upload to LuaRocks
+        env:
+          LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
+        run: |
+          luarocks upload lua-reqwest-0.1.5-1.rockspec --api-key="$LUAROCKS_API_KEY"

--- a/lua-reqwest-0.1.5-1.rockspec
+++ b/lua-reqwest-0.1.5-1.rockspec
@@ -1,0 +1,28 @@
+package = "lua-reqwest"
+version = "0.1.5-1"
+
+source = {
+    url = "git+https://github.com/oowl/lua-reqwest",
+    tag = "0.1.5",
+}
+
+description = {
+    summary = "A Lua HTTP client based on rust reqwest",
+    detailed = [[
+        A Lua HTTP client based on rust reqwest
+    ]],
+    homepage = "https://github.com/oowl/lua-reqwest",
+    license = "MIT"
+}
+
+dependencies = {
+    "lua >= 5.1",
+    "luarocks-build-rust-mlua",
+}
+
+build = {
+    type = "rust-mlua",
+    modules = {
+        "reqwest"
+    },
+}


### PR DESCRIPTION
Add GitHub Actions workflow for publishing to LuaRocks (supports manual trigger and tag push), and create the 0.1.5 rockspec.